### PR TITLE
Simplified groups api

### DIFF
--- a/lib/ansible/module_utils/identity/keycloak/keycloak.py
+++ b/lib/ansible/module_utils/identity/keycloak/keycloak.py
@@ -227,8 +227,13 @@ class KeycloakAuthorizationHeader(object):
         # Remove empty items, for instance missing client_secret
         self.payload = dict(
             (k, v) for k, v in temp_payload.items() if v is not None)
-        self.header = {}
-        self.refresh_token()
+        self._header = {}
+
+    @property
+    def header(self):
+        if self._header == {}:
+            self.refresh_token()
+        return self._header
 
     def refresh_token(self):
         try:
@@ -244,7 +249,7 @@ class KeycloakAuthorizationHeader(object):
                                 % (self.auth_url, str(e)))
 
         try:
-            self.header = {
+            self._header = {
                 'Authorization': 'Bearer ' + r['access_token'],
                 'Content-Type': 'application/json'
             }

--- a/lib/ansible/modules/identity/keycloak/keycloak_group.py
+++ b/lib/ansible/modules/identity/keycloak/keycloak_group.py
@@ -224,14 +224,15 @@ def main():
         realm=dict(default='master'),
         id=dict(type='str'),
         name=dict(type='str'),
-        attributes=dict(type='dict')
+        path=dict(type='str'),
+        attributes=dict(type='dict'),
     )
 
     argument_spec.update(meta_args)
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
-                           required_one_of=([['id', 'name']]))
+                           required_one_of=([['id', 'name', 'path']]))
 
     result = dict(changed=False, msg='', diff={}, group='')
 
@@ -245,21 +246,24 @@ def main():
         auth_password=module.params.get('auth_password'),
         client_secret=module.params.get('auth_client_secret'),
     )
-    kc = KeycloakAPI(module, connection_header)
 
     realm = module.params.get('realm')
     state = module.params.get('state')
     gid = module.params.get('id')
     name = module.params.get('name')
+    path = module.params.get('path')
     attributes = module.params.get('attributes')
+
 
     before_group = None         # current state of the group, for merging.
 
     # does the group already exist?
-    if gid is None:
-        before_group = kc.get_group_by_name(name, realm=realm)
-    else:
+    if gid is not None:
         before_group = kc.get_group_by_groupid(gid, realm=realm)
+    elif path is not None:
+        before_group = kc.get_group_by_path(path, realm=realm)
+    else:
+        before_group = kc.get_group_by_name(name, realm=realm)
 
     before_group = {} if before_group is None else before_group
 
@@ -310,6 +314,10 @@ def main():
         # do it for real!
         kc.create_group(updated_group, realm=realm)
         after_group = kc.get_group_by_name(name, realm)
+
+        if path is not None:
+            parent = kc.get_group_by_path(path[:-len(name)-1], realm=realm)
+            kc.add_group_to_parent(parent, child=after_group, realm=realm)
 
         result['group'] = after_group
         result['msg'] = 'Group {name} has been created with ID {id}'.format(name=after_group['name'],


### PR DESCRIPTION
##### SUMMARY

- Rebase on latest `stable-2.8`
- Adds the `path` parameter to help managing sub groups.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Keycloak module

##### ADDITIONAL INFORMATION
The module now comes with a caching mechanisms in order to avoid costly calls to the groups endpoint. It is triggered by reinjecting the `group_cache` value of an ending call to the `keycloak_group` module in the `group_cache` variable of the next call:
```paste below
- name: Create a Keycloak groups
  keycloak_group:
    name: "{{ item.name }}"
    path: "{{ item.path | default(omit) }}"
    realm: my-realm
    state: present
    ...
    group_cache: "{{ result.group_cache | default(omit) }}"
  register: result
  loop:
    - name: my-group
    - name: my-sub-group
      path: /my-group/my-sub-group
```
